### PR TITLE
Switch back to using Sale instead of Authorization+Capture

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -156,7 +156,7 @@ module Spree
           ShipToAddress: address_options,
           PaymentDetailsItem: items,
           ShippingMethod: "Shipping Method Name Goes Here",
-          PaymentAction: "Authorization"
+          PaymentAction: "Sale"
         }
       end
     end


### PR DESCRIPTION
This got switched in some recent updates that we pulled in for Solidus 1.4 compatibility. We've had some issues (we're never triggering the capture, and refunds are giving strange errors) so this is an attempt to switch back.

Code adapted from [the previous version](https://github.com/Lostmyname/solidus_paypal_express/blob/6f4ceaae8a17ef2c882ef9020699275bb66ff99a/app/models/spree/gateway/pay_pal_express.rb#L38-L76).

TODO:
- Make this an option instead of being hard-coded
- Fix & update specs
