### PR TITLE
Update controller to handle presence of confirm state

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -62,7 +62,8 @@ module Spree
           payment_method: payment_method
         }
       )
-      order.next
+      order.contents.advance
+      order.complete if order.can_complete?
       if order.complete?
         flash.notice = Spree.t(:order_processed_successfully)
         flash[:order_completed] = true


### PR DESCRIPTION
I would include a spec but the specs are broken on this iirc and the upstream gem is abandoned :(
We need to take another stab at getting rid of it by updating our Braintree integration.